### PR TITLE
Release/1.3.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2021-2022 Snowplow Analytics Ltd.
+   Copyright (c) 2021-2023 Snowplow Analytics Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ After pushing the changes, Google Tag Manager should update the template in the 
 
 ## Copyright and license
 
-Copyright (c) 2021-2022 Snowplow Analytics Ltd.
+Copyright (c) 2021-2023 Snowplow Analytics Ltd.
 
 Licensed under the **[Apache License, Version 2.0](LICENSE)** (the "License");
 you may not use this software except in compliance with the License.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,6 +2,14 @@ homepage: "https://snowplow.io"
 documentation: "https://docs.snowplow.io/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/google-tag-manager-custom-template/template-for-javascript-tracker-v3/settings-variable-guide"
 versions:
   # Latest version
+  - sha: 71a0349386ddf86a913902f336f66d7b54e091d1
+    changeNotes: |2
+      Add client session option in predefined contexts (#23)
+      Fix typo in Server Anonymisation toggle (#20)
+      Update Copyright to 2023 (#18)
+      Fix unpkg CDN url (#17)
+      Disallow trailing slash in collector hostname (#16)
+  # Older versions
   - sha: cd1d1a85ca0bd51bcf8698c10dd59cefc3f342b1
     changeNotes: |2
       Switch to snowplow.io domain (#15)
@@ -9,7 +17,6 @@ versions:
       Add option to not inject JavaScript library (#13)
       Format template with prettier (#10)
       Update cookieName help text to highlight the default value difference from the JavaScript tracker (#9)
-  # Older versions
   - sha: 7ecf32d171cf66fce956d1eff8fb0fded38d340d
     changeNotes: Fix metadata.yaml syntax (#7)
   - sha: 72fc820682a4f413e34a13650c8d7b89c7ee7383

--- a/template.tpl
+++ b/template.tpl
@@ -54,10 +54,13 @@ ___TEMPLATE_PARAMETERS___
         "valueValidators": [
           {
             "args": [
-              "^\\S+$"
+              "^\\S+[^/]$"
             ],
-            "errorMessage": "You must provide a valid hostname.",
+            "errorMessage": "You must provide a valid hostname. Please check that no whitespace or trailing slashes are included.",
             "type": "REGEX"
+          },
+          {
+            "type": "NON_EMPTY"
           }
         ],
         "displayName": "Collector Endpoint Hostname",

--- a/template.tpl
+++ b/template.tpl
@@ -158,7 +158,7 @@ ___TEMPLATE_PARAMETERS___
                 "errorMessage": "The sp.js library version number must be greater or equal to 3 (e.g. 3.1.5)."
               }
             ],
-            "valueHint": "3.5.0"
+            "valueHint": "3.8.0"
           }
         ]
       }
@@ -752,7 +752,7 @@ ___TEMPLATE_PARAMETERS___
 ___SANDBOXED_JS_FOR_WEB_TEMPLATE___
 
 const UNPKG =
-  'https://unpkg.com/browse/@snowplow/javascript-tracker@' +
+  'https://unpkg.com/@snowplow/javascript-tracker@' +
   data.version +
   '/dist/sp.js';
 const JSDELIVR =
@@ -901,7 +901,7 @@ scenarios:
         trackerName: mockData.trackerName,
         collectorEndpoint: mockData.collectorEndpoint,
         libUrl:
-          'https://unpkg.com/browse/@snowplow/javascript-tracker@' +
+          'https://unpkg.com/@snowplow/javascript-tracker@' +
           mockData.version +
           '/dist/sp.js',
       },

--- a/template.tpl
+++ b/template.tpl
@@ -293,8 +293,8 @@ ___TEMPLATE_PARAMETERS___
         "subParams": [
           {
             "type": "CHECKBOX",
-            "name": "withServerAnonymization",
-            "checkboxText": "Server Anonymization",
+            "name": "withServerAnonymisation",
+            "checkboxText": "Server Anonymisation",
             "simpleValueType": true,
             "enablingConditions": [
               {
@@ -773,12 +773,15 @@ const anonymousTracking = (() => {
     !data.anonymousTracking
   ) {
     return false;
-  } else if (data.anonymousTracking === 'anonymousTrackingTrue') {
+  }
+
+  if (data.anonymousTracking === 'anonymousTrackingTrue') {
     return {
       withServerAnonymisation: data.withServerAnonymisation || false,
       withSessionTracking: data.withSessionTracking || false,
     };
   }
+
   return data.anonymousTracking;
 })();
 
@@ -1073,6 +1076,178 @@ scenarios:
 
     // Call runCode to run the template's code.
     let variableResult = runCode(mockData);
+    assertThat(variableResult).isEqualTo(expected);
+- name: Test anonymous tracking true - options true
+  code: |
+    const mockData = {
+      trackerName: 'spTracker',
+      collectorEndpoint: 'test',
+
+      spLibrary: 'jsDelivr',
+      version: '3.5.0',
+
+      appId: 'my-site',
+      platform: 'web',
+
+      respectDoNotTrack: true,
+      anonymousTracking: 'anonymousTrackingTrue',
+      withSessionTracking: true,
+      withServerAnonymisation: true,
+
+      stateStorageStrategy: 'cookieAndLocalStorage',
+      cookieDomain: 'auto',
+      cookieName: 'sp',
+      cookieLifetime: 63072000,
+      cookieSameSite: 'Lax',
+      sessionCookieTimeout: '1800',
+      cookieSecure: true,
+      maxLocalStorageQueueSize: '1000',
+
+      eventMethod: 'post',
+      postPath: '/com.snowplowanalytics.snowplow/tp2',
+      bufferSize: '1',
+      encodeBase64: true,
+      maxPostBytes: '40000',
+      connectionTimeout: '5000',
+
+      webPage: true,
+      gaCookies: false,
+      clientHints: false,
+      performanceTiming: false,
+      geolocation: false,
+    };
+
+    const expected = {
+      type: 'snowplow',
+      appId: mockData.appId,
+      platform: mockData.platform,
+      respectDoNotTrack: mockData.respectDoNotTrack,
+      stateStorageStrategy: mockData.stateStorageStrategy,
+      cookieDomain: false,
+      discoverRootDomain: true,
+      cookieName: mockData.cookieName,
+      cookieLifetime: mockData.cookieLifetime,
+      cookieSameSite: 'Lax',
+      cookieSecure: mockData.cookieSecure,
+      sessionCookieTimeout: mockData.sessionCookieTimeout,
+      maxLocalStorageQueueSize: mockData.maxLocalStorageQueueSize,
+      eventMethod: mockData.eventMethod,
+      encodeBase64: mockData.encodeBase64,
+      bufferSize: mockData.bufferSize,
+      postPath: mockData.postPath,
+      maxPostBytes: mockData.maxPostBytes,
+      connectionTimeout: mockData.connectionTimeout,
+      anonymousTracking: {
+        withSessionTracking: true,
+        withServerAnonymisation: true,
+      },
+      contexts: {
+        webPage: mockData.webPage,
+        performanceTiming: mockData.performanceTiming,
+        gaCookies: mockData.gaCookies,
+        geolocation: mockData.geolocation,
+        clientHints: mockData.clientHints,
+      },
+      trackerOptions: {
+        trackerName: mockData.trackerName,
+        collectorEndpoint: mockData.collectorEndpoint,
+        libUrl:
+          'https://cdn.jsdelivr.net/npm/@snowplow/javascript-tracker@' +
+          mockData.version +
+          '/dist/sp.min.js',
+      },
+    };
+
+    // Call runCode to run the template's code.
+    let variableResult = runCode(mockData);
+
+    // Verify that the variable returns a result.
+    assertThat(variableResult).isEqualTo(expected);
+- name: Test anonymous tracking true - options false
+  code: |
+    const mockData = {
+      trackerName: 'spTracker',
+      collectorEndpoint: 'test',
+
+      spLibrary: 'jsDelivr',
+      version: '3.5.0',
+
+      appId: 'my-site',
+      platform: 'web',
+
+      respectDoNotTrack: true,
+      anonymousTracking: 'anonymousTrackingTrue',
+      withSessionTracking: false,
+      withServerAnonymisation: false,
+
+      stateStorageStrategy: 'cookieAndLocalStorage',
+      cookieDomain: 'auto',
+      cookieName: 'sp',
+      cookieLifetime: 63072000,
+      cookieSameSite: 'Lax',
+      sessionCookieTimeout: '1800',
+      cookieSecure: true,
+      maxLocalStorageQueueSize: '1000',
+
+      eventMethod: 'post',
+      postPath: '/com.snowplowanalytics.snowplow/tp2',
+      bufferSize: '1',
+      encodeBase64: true,
+      maxPostBytes: '40000',
+      connectionTimeout: '5000',
+
+      webPage: true,
+      gaCookies: false,
+      clientHints: false,
+      performanceTiming: false,
+      geolocation: false,
+    };
+
+    const expected = {
+      type: 'snowplow',
+      appId: mockData.appId,
+      platform: mockData.platform,
+      respectDoNotTrack: mockData.respectDoNotTrack,
+      stateStorageStrategy: mockData.stateStorageStrategy,
+      cookieDomain: false,
+      discoverRootDomain: true,
+      cookieName: mockData.cookieName,
+      cookieLifetime: mockData.cookieLifetime,
+      cookieSameSite: 'Lax',
+      cookieSecure: mockData.cookieSecure,
+      sessionCookieTimeout: mockData.sessionCookieTimeout,
+      maxLocalStorageQueueSize: mockData.maxLocalStorageQueueSize,
+      eventMethod: mockData.eventMethod,
+      encodeBase64: mockData.encodeBase64,
+      bufferSize: mockData.bufferSize,
+      postPath: mockData.postPath,
+      maxPostBytes: mockData.maxPostBytes,
+      connectionTimeout: mockData.connectionTimeout,
+      anonymousTracking: {
+        withSessionTracking: false,
+        withServerAnonymisation: false,
+      },
+      contexts: {
+        webPage: mockData.webPage,
+        performanceTiming: mockData.performanceTiming,
+        gaCookies: mockData.gaCookies,
+        geolocation: mockData.geolocation,
+        clientHints: mockData.clientHints,
+      },
+      trackerOptions: {
+        trackerName: mockData.trackerName,
+        collectorEndpoint: mockData.collectorEndpoint,
+        libUrl:
+          'https://cdn.jsdelivr.net/npm/@snowplow/javascript-tracker@' +
+          mockData.version +
+          '/dist/sp.min.js',
+      },
+    };
+
+    // Call runCode to run the template's code.
+    let variableResult = runCode(mockData);
+
+    // Verify that the variable returns a result.
     assertThat(variableResult).isEqualTo(expected);
 setup: ''
 

--- a/template.tpl
+++ b/template.tpl
@@ -743,6 +743,14 @@ ___TEMPLATE_PARAMETERS___
         "name": "geolocation",
         "checkboxText": "geolocation",
         "type": "CHECKBOX"
+      },
+      {
+        "type": "CHECKBOX",
+        "name": "session",
+        "checkboxText": "session",
+        "simpleValueType": true,
+        "help": "Adds client session context entity to events, provided that anonymous tracking is disabled. This option is only available since version 3.5 of the Snowplow JavaScript tracker.",
+        "defaultValue": false
       }
     ]
   }
@@ -814,6 +822,7 @@ return {
     gaCookies: data.gaCookies,
     clientHints: data.clientHints,
     geolocation: data.geolocation,
+    session: data.session,
   },
   trackerOptions: {
     trackerName: data.trackerName,
@@ -867,6 +876,7 @@ scenarios:
       gaCookies: false,
       clientHints: false,
       geolocation: false,
+      session: false,
     };
 
     const expected = {
@@ -899,6 +909,7 @@ scenarios:
         gaCookies: mockData.gaCookies,
         geolocation: mockData.geolocation,
         clientHints: mockData.clientHints,
+        session: mockData.session,
       },
       trackerOptions: {
         trackerName: mockData.trackerName,
@@ -951,6 +962,7 @@ scenarios:
       clientHints: false,
       performanceTiming: false,
       geolocation: false,
+      session: true,
     };
 
     const expected = {
@@ -980,6 +992,7 @@ scenarios:
         gaCookies: mockData.gaCookies,
         geolocation: mockData.geolocation,
         clientHints: mockData.clientHints,
+        session: mockData.session,
       },
       trackerOptions: {
         trackerName: mockData.trackerName,
@@ -1037,6 +1050,7 @@ scenarios:
       clientHints: false,
       performanceTiming: false,
       geolocation: false,
+      session: false,
     };
 
     const expected = {
@@ -1066,6 +1080,7 @@ scenarios:
         gaCookies: mockData.gaCookies,
         geolocation: mockData.geolocation,
         clientHints: mockData.clientHints,
+        session: mockData.session,
       },
       trackerOptions: {
         trackerName: mockData.trackerName,
@@ -1115,6 +1130,7 @@ scenarios:
       clientHints: false,
       performanceTiming: false,
       geolocation: false,
+      session: false,
     };
 
     const expected = {
@@ -1147,6 +1163,7 @@ scenarios:
         gaCookies: mockData.gaCookies,
         geolocation: mockData.geolocation,
         clientHints: mockData.clientHints,
+        session: mockData.session,
       },
       trackerOptions: {
         trackerName: mockData.trackerName,
@@ -1201,6 +1218,7 @@ scenarios:
       clientHints: false,
       performanceTiming: false,
       geolocation: false,
+      session: false,
     };
 
     const expected = {
@@ -1233,6 +1251,7 @@ scenarios:
         gaCookies: mockData.gaCookies,
         geolocation: mockData.geolocation,
         clientHints: mockData.clientHints,
+        session: mockData.session,
       },
       trackerOptions: {
         trackerName: mockData.trackerName,


### PR DESCRIPTION
Switching from  https://github.com/snowplow/snowplow-gtm-variable-template-v3/pull/19 (approved) to `1.3.0` , because of #23 (new feature).